### PR TITLE
Removed :age from expected output in 5-4

### DIFF
--- a/test/workshop/jobs/test_5_4.clj
+++ b/test/workshop/jobs/test_5_4.clj
@@ -35,8 +35,8 @@
    {:username "Lucas"}])
 
 (def expected-child-output
-  [{:username "Ron" :age 16}
-   {:username "Kara" :age 14}])
+  [{:username "Ron"}
+   {:username "Kara"}])
 
 (deftest test-level-5-challenge-4
   (try


### PR DESCRIPTION
The instructions state that age is only useful for routing, and it should be removed afterwards, so it makes more sense to remove it from both. Could also rework the instructions to clarify requirements regarding children's age.