### PR TITLE
Fix get window-id for 6.x challenges

### DIFF
--- a/src/workshop/challenge_6_0.clj
+++ b/src/workshop/challenge_6_0.clj
@@ -176,9 +176,10 @@
 ;;
 ;; While we use an atom here for ease, this is the ideal place to synchronize
 ;; window state to an external database or other 3rd party medium.
-(defn deliver-promise! [event window trigger {:keys [window-id lower-bound upper-bound]} state]
+(defn deliver-promise! [event window  {:keys [trigger/window-id] :as trigger} {:keys [lower-bound upper-bound] :as state-event} state]
   (let [lower (java.util.Date. lower-bound)
         upper (java.util.Date. upper-bound)]
+    (println "Trigger for" window-id "window")    
     (swap! fired-window-state assoc [lower upper] (into #{} state))))
 
 ;; Finally, it's important to note that if a machine fails before

--- a/src/workshop/challenge_6_1.clj
+++ b/src/workshop/challenge_6_1.clj
@@ -66,7 +66,7 @@
 
 (def fired-window-state (atom {}))
 
-(defn deliver-promise! [event window trigger {:keys [window-id lower-bound upper-bound]} state]
+(defn deliver-promise! [event window {:keys [trigger/window-id] :as trigger} {:keys [lower-bound upper-bound] :as state-event} state]
   ;; <<< BEGIN FILL ME IN PART 2 >>>
 
   ;; <<< END FILL ME IN PART 2 >>>

--- a/src/workshop/challenge_6_2.clj
+++ b/src/workshop/challenge_6_2.clj
@@ -66,7 +66,7 @@
 
 (def fired-window-state (atom {}))
 
-(defn deliver-promise! [event window trigger {:keys [window-id lower-bound upper-bound]} state]
+(defn deliver-promise! [event window {:keys [trigger/window-id] :as trigger} {:keys [lower-bound upper-bound] :as state-event} state]
   ;; <<< BEGIN FILL ME IN PART 2 >>>
 
   ;; <<< END FILL ME IN PART 2 >>>


### PR DESCRIPTION
There is no 'window-id' key inside state-event input parameter for method called by trigger.
```clojure
:trigger/sync ::deliver-promise!

(defn deliver-promise! [event window trigger {:keys [window-id lower-bound upper-bound]} state]
  (let [lower (java.util.Date. lower-bound)
        upper (java.util.Date. upper-bound)]
    (swap! fired-window-state assoc [lower upper] (into #{} state))))
```
We can get 'window-id' from `window` or `trigger` parameter
```clojure
(defn deliver-promise! [event window  {:keys [trigger/window-id] :as trigger} {:keys [lower-bound upper-bound] :as state-event} state]
  (let [lower (java.util.Date. lower-bound)
        upper (java.util.Date. upper-bound)]
    (println "Trigger for" window-id "window")    
    (swap! fired-window-state assoc [lower upper] (into #{} state))))
```