### PR TITLE
Set workflow as an empty vector for 1.x challanges

### DIFF
--- a/src/workshop/challenge_1_1.clj
+++ b/src/workshop/challenge_1_1.clj
@@ -5,7 +5,7 @@
 
 ;;; <<< BEGIN FILL ME IN >>>
 
-(def workflow)
+(def workflow [])
 
 ;;; <<< END FILL ME IN >>>
 

--- a/src/workshop/challenge_1_2.clj
+++ b/src/workshop/challenge_1_2.clj
@@ -5,7 +5,7 @@
 
 ;;; <<< BEGIN FILL ME IN >>>
 
-(def workflow)
+(def workflow [])
 
 ;;; <<< END FILL ME IN >>>
 

--- a/src/workshop/challenge_1_3.clj
+++ b/src/workshop/challenge_1_3.clj
@@ -5,7 +5,7 @@
 
 ;;; <<< BEGIN FILL ME IN >>>
 
-(def workflow)
+(def workflow [])
 
 ;;; <<< END FILL ME IN >>>
 


### PR DESCRIPTION
Change from
```clojure
(def workflow)
```
to
```clojure
(def workflow [])
```
To get rid of unbound var exception.