### PR TITLE
Small changes for Challenge 3_1

### DIFF
--- a/src/workshop/challenge_3_1.clj
+++ b/src/workshop/challenge_3_1.clj
@@ -31,15 +31,19 @@
        :onyx/doc "Converts :name to all upper-case letters."}
 
       {:onyx/name :interpose-pipe
-       :onyx/fn :workshop.challenge-3-1/interpose-pipe
+       :onyx/fn :workshop.challenge-3-1/interpose-char
        :onyx/type :function
+       :my/char "|"
+       :onyx/params [:my/char]
        :onyx/batch-size batch-size
        :onyx/batch-timeout batch-timeout
        :onyx/doc "Interposes the pipe character (|) between all chars in :name"}
 
       {:onyx/name :interpose-space
-       :onyx/fn :workshop.challenge-3-1/interpose-space
+       :onyx/fn :workshop.challenge-3-1/interpose-char
        :onyx/type :function
+       :my/char " "
+       :onyx/params [:my/char]
        :onyx/batch-size batch-size
        :onyx/batch-timeout batch-timeout
        :onyx/doc "Interposes a single space character between all chars in :name"}

--- a/test/workshop/jobs/challenge_3_1_test.clj
+++ b/test/workshop/jobs/challenge_3_1_test.clj
@@ -7,8 +7,9 @@
 
 ;; Now that you know the rules of functions, let's implement some
 ;; functions for a workflow. This Onyx job will have 3 function tasks.
-;; You'll need to implement the functions to pass the test. Read
-;; the docstrings on the corresponding catalog entries for the
+;; You'll need to implement the functions to pass the test.  Use a
+;; generic function that builds on the lessons from challenge_2_2.
+;; Read the docstrings on the corresponding catalog entries for the
 ;; functions' purposes.
 ;;
 ;; Try it with:


### PR DESCRIPTION
For #33 

Replaces `interpose-space` and `interpose-pipe` with `interpose-char`.  Also sets `:onyx/params` leaving user to focus on the actual function definition rather than the catalogue.

Test passes for me with:

```clojure
(defn upper-case
  [{:keys [name]}]
  {:name ((memfn toUpperCase) name)})

(defn interpose-char
  [c segment]
  (update-in segment [:name] #(apply str (interpose c %))))
```