### PR TITLE
Remove `logger-lifecycle` in challenge 4.1

### DIFF
--- a/src/workshop/challenge_4_1.clj
+++ b/src/workshop/challenge_4_1.clj
@@ -53,9 +53,6 @@
 (defn inject-writer-ch [event lifecycle]
   {:core.async/chan (u/get-output-channel (:core.async/id lifecycle))})
 
-(def logger-lifecycle
-  {:lifecycle/after-batch log-segments})
-
 (def writer-lifecycle
   {:lifecycle/before-task-start inject-writer-ch})
 


### PR DESCRIPTION
It seems to me that `logger-lifecycle` should be the answer of next block, but it's exposed. Having it there will also cause issues with `(reset)` as `log-segments` is not defined, if you haven't come to this challenge.